### PR TITLE
Precompute fingerprints regex expressions for performance

### DIFF
--- a/shelldetect.py
+++ b/shelldetect.py
@@ -155,9 +155,9 @@ class ShellDetector:
 
     def anaylize(self):
         _counter = 0
+        _regex = re.compile(self._regex)
         for _filename in self._files:
             _content = open(_filename, 'rt', -1).read()
-            _regex = re.compile(self._regex)
             _match = _regex.findall(_content)
             if _match:
                 self.getfileinfo(_filename)


### PR DESCRIPTION
I've found that if you precompute all the fingerprint regular expressions you get a HUGE boost on performance:

from 

real    0m42.765s
user    0m40.347s
sys 0m0.168s

to 

real    0m5.536s
user    0m4.016s
sys 0m0.144s
